### PR TITLE
Add `overrideEntry: false` option to disable Markdown code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,19 @@ It's also possible to customize the url by appending _query parameters_. Just ap
 
 Want to use custom templates and keep them version controlled in the same repository? Use `file:` schema to load templates directly from the file system! The below code will load the template from the path `./templates/vanilla-console`, relative to the markdown file. The file templates are directories with at least a `package.json` file inside.
 
+As in the other examples, the content of the code block will replace the entry file in the template.
+
 ````md
 ```js codesandbox=file:./templates/vanilla-console
-// ...
+console.log('this code will replace the entry file content');
+```
+````
+
+If you would like to use the template as-is without any of the content of the code block, add the `?overrideEntry=false` query string:
+
+````md
+```js codesandbox=file:./templates/vanilla-console?overrideEntry=false
+// This code will not be added to the sandbox
 ```
 ````
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ If you would like to use the template as-is without any of the content of the co
 ```
 ````
 
+This `?overrideEntry=false` will not be set as a query parameter on the sandbox, since it is only important for the plugin itself.
+
 The path is too long to type every time? Consider creating it as a [custom template](#customTemplates). It's also the recommended way!
 
 > Pro tip: You can create file templates directly on [codesandbox.io/s](https://codesandbox.io/s) and download them by selecting `File` -> `Export to ZIP` in the menu bar. Unzip it somewhere and... Abrahadabra! You got yourself a file template!

--- a/examples/gatsby-mdx/src/pages/index.mdx
+++ b/examples/gatsby-mdx/src/pages/index.mdx
@@ -22,7 +22,7 @@ export default function App() {
 }
 ```
 
-This one is versioned along side the code 🤯
+This one is versioned alongside the code 🤯
 
 ```js codesandbox=vanilla-console
 console.log('Hello remark-codesandbox!');

--- a/examples/mdx/index.mdx
+++ b/examples/mdx/index.mdx
@@ -25,7 +25,9 @@ export default function App() {
 This one is versioned alongside the code 🤯
 
 ```js codesandbox=file:./my-template
-console.log('yayy');
+document.getElementById('app').innerHTML = `
+<h1>Hello remark-codesandbox</h1>
+`
 ```
 
 If you would like to use the template as-is without any of the content of the

--- a/examples/mdx/index.mdx
+++ b/examples/mdx/index.mdx
@@ -21,3 +21,16 @@ export default function App() {
   return <h1>Hello remark-codesandbox!</h1>;
 }
 ```
+
+This one is versioned alongside the code 🤯
+
+```js codesandbox=file:./my-template
+console.log('yayy');
+```
+
+If you would like to use the template as-is without any of the content of the
+code block, add the `?overrideEntry=false` query string:
+
+```js codesandbox=file:./my-template?overrideEntry=false
+// This code will not be added to the sandbox
+```

--- a/examples/mdx/my-template/index.html
+++ b/examples/mdx/my-template/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Parcel Sandbox</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <script src="src/index.js"></script>
+  </body>
+</html>

--- a/examples/mdx/my-template/package.json
+++ b/examples/mdx/my-template/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vanilla",
+  "description": "JavaScript example starter project",
+  "main": "index.html",
+  "scripts": {
+    "start": "parcel index.html --open",
+    "build": "parcel build index.html"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@babel/core": "7.2.0",
+    "parcel-bundler": "^1.6.1"
+  },
+  "keywords": [
+    "javascript",
+    "starter"
+  ]
+}

--- a/examples/mdx/my-template/src/index.js
+++ b/examples/mdx/my-template/src/index.js
@@ -1,0 +1,7 @@
+document.getElementById('app').innerHTML = `
+<h1>Hello Vanilla!</h1>
+<div>
+  We use Parcel to bundle this sandbox, you can find more info about Parcel
+  <a href="https://parceljs.org" target="_blank" rel="noopener noreferrer">here</a>.
+</div>
+`;

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -101,10 +101,16 @@ function codesandbox(options = {}) {
         );
       }
 
+      const overrideEntry = query.get('overrideEntry') || options.overrideEntry || true;
+
+      // Remove any options that are only for the plugin and not relevant to CodeSandbox
+      const pluginOnlyQueryParams = ['overrideEntry'];
+      pluginOnlyQueryParams.forEach(query.delete);
+
       const parameters = getParameters({
         files: {
           ...template.files,
-          [template.entry]: { content: node.value },
+          ...(overrideEntry && {[template.entry]: { content: node.value }),
         },
       });
 

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -108,7 +108,9 @@ function codesandbox(options = {}) {
 
       // Remove any options that are only for the plugin and not relevant to CodeSandbox
       const pluginOnlyQueryParams = ['overrideEntry'];
-      pluginOnlyQueryParams.forEach(query.delete);
+      pluginOnlyQueryParams.forEach(param => {
+        query.delete(param);
+      });
 
       const parameters = getParameters({
         files: {

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -103,10 +103,7 @@ function codesandbox(options = {}) {
         );
       }
 
-      const overrideEntry =
-        query.get('overrideEntry') !== 'false' ||
-        options.overrideEntry ||
-        true;
+      const overrideEntry = query.get("overrideEntry") !== "false" || true;
 
       // Remove any options that are only for the plugin and not relevant to CodeSandbox
       PLUGIN_ONLY_QUERY_PARAMS.forEach(param => {

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -28,6 +28,8 @@ const DEFAULT_CUSTOM_TEMPLATES = {
   },
 };
 
+const PLUGIN_ONLY_QUERY_PARAMS = ['overrideEntry'];
+
 function codesandbox(options = {}) {
   const templates = new Map();
   const mode = options.mode || 'meta';
@@ -107,8 +109,7 @@ function codesandbox(options = {}) {
         true;
 
       // Remove any options that are only for the plugin and not relevant to CodeSandbox
-      const pluginOnlyQueryParams = ['overrideEntry'];
-      pluginOnlyQueryParams.forEach(param => {
+      PLUGIN_ONLY_QUERY_PARAMS.forEach(param => {
         query.delete(param);
       });
 

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -103,7 +103,7 @@ function codesandbox(options = {}) {
         );
       }
 
-      const overrideEntry = query.get("overrideEntry") !== "false" || true;
+      const overrideEntry = query.get("overrideEntry") !== "false";
 
       // Remove any options that are only for the plugin and not relevant to CodeSandbox
       PLUGIN_ONLY_QUERY_PARAMS.forEach(param => {

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -113,7 +113,7 @@ function codesandbox(options = {}) {
       const parameters = getParameters({
         files: {
           ...template.files,
-          ...(overrideEntry && {[template.entry]: { content: node.value }),
+          ...(overrideEntry && {[template.entry]: { content: node.value }}),
         },
       });
 

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -101,7 +101,10 @@ function codesandbox(options = {}) {
         );
       }
 
-      const overrideEntry = query.get('overrideEntry') || options.overrideEntry || true;
+      const overrideEntry =
+        query.get('overrideEntry') !== 'false' ||
+        options.overrideEntry ||
+        true;
 
       // Remove any options that are only for the plugin and not relevant to CodeSandbox
       const pluginOnlyQueryParams = ['overrideEntry'];


### PR DESCRIPTION
Closes https://github.com/kevin940726/remark-codesandbox/issues/7