### PR TITLE
Allow override entry's range

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,22 +178,6 @@ It's also possible to use any existing sandbox. Just get the `id` of the sandbox
 ```
 ````
 
-It's also possible to customize the url by appending _query parameters_. Just append them after the sandbox id. All [options](https://codesandbox.io/docs/embedding#embed-options) are allowed.
-
-````md
-```js codesandbox=new?codemirror=1&fontsize=12
-// ...
-```
-````
-
-A special query param `entry` is introduced to allow you to override the specific file with the contents of the code block.
-
-````md
-```js codesandbox=new?entry=src/App.js
-// Override `src/App.js` rather than the default `src/index.js` with this contents of the code block
-```
-````
-
 Want to use custom templates and keep them version controlled in the same repository? Use `file:` schema to load templates directly from the file system! The below code will load the template from the path `./templates/vanilla-console`, relative to the markdown file. The file templates are directories with at least a `package.json` file inside.
 
 As in the other examples, the content of the code block will replace the entry file in the template.
@@ -204,6 +188,60 @@ console.log('this code will replace the entry file content');
 ```
 ````
 
+The path is too long to type every time? Consider creating it as a [custom template](#customTemplates). It's also the recommended way!
+
+> Pro tip: You can create file templates directly on [codesandbox.io/s](https://codesandbox.io/s) and download them by selecting `File` -> `Export to ZIP` in the menu bar. Unzip it somewhere and... Abrahadabra! You got yourself a file template!
+
+### Query params
+
+It's also possible to customize the url by appending _query parameters_. Just append them after the sandbox id. All [options](https://codesandbox.io/docs/embedding#embed-options) are allowed.
+
+````md
+```js codesandbox=new?codemirror=1&fontsize=12
+// ...
+```
+````
+
+There are several _special query params_ you can set inline. All the special query params below will not be passed to the generated CodeSandbox URL, as they are not officially supported.
+
+#### `entry`
+
+A special query param `entry` is introduced to allow you to override the specific file with the contents of the code block.
+
+````md
+```js codesandbox=new?entry=src/App.js
+// Override `src/App.js` rather than the default `src/index.js` with this contents of the code block
+```
+````
+
+#### `overrideEntry`
+
+By default, contents in the code block will override all the contents in the entry file. You can change this by setting the special query param `overrideEntry`.
+
+Set `overrideEntry` to _a range of line numbers_ to specify which part of the entry file you want the code block to override. The below example will replace the entry file of the `react` template (`src/index.js`) from line 4 to 12 with the contents in the code block.
+
+````md
+```js codesandbox=react?overrideEntry=4-12
+ReactDOM.render(
+  <h1>Hello remark-codesandbox!</h1>,
+  document.getElementById('root')
+);
+```
+````
+
+With this tip, you can avoid passing unrelated code into the code block, so that the readers can focus on what really matters.
+
+There's a handy shortcut to only specify the start line without the end line to replace the whole entry file starting from a specific line number without knowing how long it is.
+
+````md
+```js codesandbox=react?overrideEntry=4-
+ReactDOM.render(
+  <h1>Hello remark-codesandbox!</h1>,
+  document.getElementById('root')
+);
+```
+````
+
 If you would like to use the template as-is without any of the content of the code block, add the `?overrideEntry=false` query string:
 
 ````md
@@ -211,12 +249,6 @@ If you would like to use the template as-is without any of the content of the co
 // This code will not be added to the sandbox
 ```
 ````
-
-This `?overrideEntry=false` will not be set as a query parameter on the sandbox, since it is only important for the plugin itself.
-
-The path is too long to type every time? Consider creating it as a [custom template](#customTemplates). It's also the recommended way!
-
-> Pro tip: You can create file templates directly on [codesandbox.io/s](https://codesandbox.io/s) and download them by selecting `File` -> `Export to ZIP` in the menu bar. Unzip it somewhere and... Abrahadabra! You got yourself a file template!
 
 ### Options
 

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -107,19 +107,33 @@ function codesandbox(options = {}) {
         );
       }
 
-      const overrideEntry = query.get('overrideEntry') !== 'false';
+      const overrideEntry = query.get('overrideEntry');
 
       // Remove any options that are only for the plugin and not relevant to CodeSandbox
       PLUGIN_ONLY_QUERY_PARAMS.forEach((param) => {
         query.delete(param);
       });
 
+      let entryFileContent = template.files[entryPath].content;
+      if (!overrideEntry) {
+        entryFileContent = node.value;
+      } else if (overrideEntry !== 'false') {
+        const [overrideRangeStart, overrideRangeEnd] = overrideEntry
+          .split('-')
+          .map((line) => Number(line));
+
+        const lines = entryFileContent.split('\n');
+        entryFileContent = [
+          ...lines.slice(0, overrideRangeStart - 1),
+          node.value,
+          ...lines.slice(overrideRangeEnd),
+        ].join('\n');
+      }
+
       const parameters = getParameters({
         files: {
           ...template.files,
-          ...(overrideEntry && {
-            [entryPath]: { content: node.value },
-          }),
+          [entryPath]: { content: entryFileContent },
         },
       });
 

--- a/packages/remark-codesandbox/src/index.js
+++ b/packages/remark-codesandbox/src/index.js
@@ -124,9 +124,11 @@ function codesandbox(options = {}) {
 
         const lines = entryFileContent.split('\n');
         entryFileContent = [
-          ...lines.slice(0, overrideRangeStart - 1),
+          ...lines.slice(0, Number(overrideRangeStart) - 1),
           node.value,
-          ...lines.slice(overrideRangeEnd),
+          ...(overrideRangeEnd === ''
+            ? []
+            : lines.slice(Number(overrideRangeEnd))),
         ].join('\n');
       }
 

--- a/packages/remark-codesandbox/test.js
+++ b/packages/remark-codesandbox/test.js
@@ -501,7 +501,7 @@ describe('overrideEntry', () => {
     const md = dedent`
       The below code block will create codesandbox and inject custom query.
 
-      \`\`\`css codesandbox=react?overrideEntry=4-12
+      \`\`\`js codesandbox=react?overrideEntry=4-12
       ReactDOM.render(
         <h1>Hello remark-codesandbox!</h1>,
         document.getElementById('root')
@@ -514,7 +514,7 @@ describe('overrideEntry', () => {
     expect(contents).toMatchStringWithPatterns`
       "The below code block will create codesandbox and inject custom query.
 
-      \`\`\`css codesandbox=react?overrideEntry=4-12
+      \`\`\`js codesandbox=react?overrideEntry=4-12
       ReactDOM.render(
         <h1>Hello remark-codesandbox!</h1>,
         document.getElementById('root')
@@ -530,7 +530,7 @@ describe('overrideEntry', () => {
     const md = dedent`
       The below code block will create codesandbox and inject custom query.
 
-      \`\`\`css codesandbox=react?overrideEntry=false
+      \`\`\`js codesandbox=react?overrideEntry=false
       import React from 'react';
       import ReactDOM from 'react-dom';
 
@@ -546,7 +546,7 @@ describe('overrideEntry', () => {
     expect(contents).toMatchStringWithPatterns`
       "The below code block will create codesandbox and inject custom query.
 
-      \`\`\`css codesandbox=react?overrideEntry=false
+      \`\`\`js codesandbox=react?overrideEntry=false
       import React from 'react';
       import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
With this entry file (`react`):

```js
import React from "react";
import ReactDOM from "react-dom";

import App from "./App";

const rootElement = document.getElementById("root");
ReactDOM.render(
  <React.StrictMode>
    <App />
  </React.StrictMode>,
  rootElement
);
```

And this markdown code block with `remark-codesandbox`

````md
```js codesandbox=react?overrideEntry=4-12
ReactDOM.render(
  <h1>Hello remark-codesandbox!</h1>,
  document.getElementById('root')
);
```
````

Renders the result with this entry file:

```js
import React from "react";
import ReactDOM from "react-dom";

ReactDOM.render(
  <h1>Hello remark-codesandbox!</h1>,
  document.getElementById('root')
);
```