### PR TITLE
Add Gatsby endpoint

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -18289,6 +18289,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["rollup", "npm:1.31.0"],
             ["rollup-plugin-babel", "virtual:99a04b83982c0182f6ee610f13d722fa43fd8f74ce6c4855b0669ee12700fb7decaa3babb02cf1ed1777d11b8259ac2c14c913a1225e699f2a4a3bfb12c8b9d7#npm:4.3.3"],
             ["rollup-plugin-terser", "virtual:99a04b83982c0182f6ee610f13d722fa43fd8f74ce6c4855b0669ee12700fb7decaa3babb02cf1ed1777d11b8259ac2c14c913a1225e699f2a4a3bfb12c8b9d7#npm:5.2.0"],
+            ["to-gatsby-remark-plugin", "npm:0.1.0"],
             ["unist-builder", "npm:2.0.2"],
             ["unist-util-is", "npm:4.0.1"],
             ["unist-util-visit", "npm:2.0.1"]

--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@
 yarn add -D remark-codesandbox
 ```
 
-Install the Gatsby version instead if you're using Gatsby.
-
-```bash
-yarn add gatsby-remark-inline-codesandbox
-```
-
 ## Getting Started
 
 Import `remark-codesandbox` to your remark plugins. (Skip this step if you're using Gatsby)
@@ -61,6 +55,8 @@ mdx(mdxCode, {
 
 [**Gatsby (gatsby-plugin-mdx)**](https://www.gatsbyjs.org/docs/mdx/plugins/#remark-plugins)
 
+Use the `/gatsby` endpoint to use the Gatsby's version of the plugin.
+
 ```js
 module.exports = {
   plugins: [
@@ -69,7 +65,7 @@ module.exports = {
       options: {
         gatsbyRemarkPlugins: [
           {
-            resolve: 'gatsby-remark-inline-codesandbox',
+            resolve: 'remark-codesandbox/gatsby',
             options: {
               mode: 'button',
             },
@@ -83,6 +79,8 @@ module.exports = {
 
 [**Gatsby (gatsby-transformer-remark)**](https://www.gatsbyjs.org/packages/gatsby-transformer-remark)
 
+Use the `/gatsby` endpoint to use the Gatsby's version of the plugin.
+
 ```js
 module.exports = {
   plugins: [
@@ -91,7 +89,7 @@ module.exports = {
       options: {
         plugins: [
           {
-            resolve: 'gatsby-remark-inline-codesandbox',
+            resolve: 'remark-codesandbox/gatsby',
             options: {
               mode: 'button',
             },

--- a/packages/remark-codesandbox/gatsby/index.js
+++ b/packages/remark-codesandbox/gatsby/index.js
@@ -1,0 +1,4 @@
+const toGatsbyRemarkPlugin = require('to-gatsby-remark-plugin');
+const codesandbox = require('../');
+
+module.exports = toGatsbyRemarkPlugin(codesandbox);

--- a/packages/remark-codesandbox/gatsby/package.json
+++ b/packages/remark-codesandbox/gatsby/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.js"
+}

--- a/packages/remark-codesandbox/package.json
+++ b/packages/remark-codesandbox/package.json
@@ -20,6 +20,7 @@
     "isomorphic-fetch": "^2.2.1",
     "mdast-util-to-string": "^1.0.7",
     "recursive-readdir": "^2.2.2",
+    "to-gatsby-remark-plugin": "^0.1.0",
     "unist-builder": "^2.0.2",
     "unist-util-is": "^4.0.1",
     "unist-util-visit": "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8058,7 +8058,7 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "gatsby-remark-inline-codesandbox@workspace:packages/gatsby-remark-inline-codesandbox"
   dependencies:
-    remark-codesandbox: "workspace:^0.8.1"
+    remark-codesandbox: "workspace:^0.8.2"
     to-gatsby-remark-plugin: ^0.1.0
   languageName: unknown
   linkType: soft
@@ -15544,7 +15544,7 @@ fsevents@~2.1.1:
   languageName: unknown
   linkType: soft
 
-"remark-codesandbox@workspace:^0.8.1, remark-codesandbox@workspace:packages/remark-codesandbox":
+"remark-codesandbox@workspace:^0.8.2, remark-codesandbox@workspace:packages/remark-codesandbox":
   version: 0.0.0-use.local
   resolution: "remark-codesandbox@workspace:packages/remark-codesandbox"
   dependencies:
@@ -15564,6 +15564,7 @@ fsevents@~2.1.1:
     rollup: ^1.31.0
     rollup-plugin-babel: ^4.3.3
     rollup-plugin-terser: ^5.2.0
+    to-gatsby-remark-plugin: ^0.1.0
     unist-builder: ^2.0.2
     unist-util-is: ^4.0.1
     unist-util-visit: ^2.0.1


### PR DESCRIPTION
Use the `/gatsby` endpoint to access the Gatsby plugin.